### PR TITLE
GitHub release triggers release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,13 @@ on:
     paths-ignore:
       - '.sdkmanrc'
       - 'README.md'
+      - 'RELEASING.md'
   pull_request:
     branches: [ main ]
     paths-ignore:
       - '.sdkmanrc'
       - 'README.md'
+      - 'RELEASING.md'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Publish package to the Maven Central Repository
+
 on:
-  push:
-    tags:
-      - v*
+  release:
+    types: [published]
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,15 @@
+# Release process
+
+Release process is semi-automated through GitHub Actions. This describes the basic steps for a project member to perform a release.
+
+## Steps
+
+1. Ensure that the `main` branch is building and that tests are passing.
+1. Create a new release on GitHub.
+1. The release triggers a GitHub Action workflow.
+1. Handcraft and polish some of the release notes (e.g. substitute combined dependency PRs and highlight certain features).
+1. Rename existing milestone corresponding to new release and close it. Then create a new `next` milestone.
+
+## Internal details
+
+* JReleaser is in charge of steps in Maven Central.


### PR DESCRIPTION
Switch from `push tag` event to `release published`. Also, add docs
for release process.
