### PR TITLE
Flyway baseline migration failing test case

### DIFF
--- a/src/test/java/org/testcontainers/jooq/codegen/PluginTest.java
+++ b/src/test/java/org/testcontainers/jooq/codegen/PluginTest.java
@@ -41,6 +41,21 @@ public class PluginTest {
     }
 
     @Test
+    public void testPostgresFlywayBaseline() throws Exception {
+        // given
+        MavenProject mavenProject = getMavenProject("postgres-flyway-baseline");
+
+        // when
+        mojoRule.lookupConfiguredMojo(mavenProject, "generate").execute();
+
+        // then
+        assertThatProject(mavenProject)
+                .hasGeneratedJooqTable("Users.java")
+                .hasGeneratedJooqTable("Person.java")
+                .hasGeneratedJooqTable("FlywaySchemaHistory.java");
+    }
+
+    @Test
     public void testPostgresLiquibase() throws Exception {
         // given
         MavenProject mavenProject = getMavenProject("postgres-liquibase");

--- a/src/test/resources/pom/postgres-flyway-baseline/pom.xml
+++ b/src/test/resources/pom/postgres-flyway-baseline/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.testcontainers</groupId>
+    <artifactId>testcontainers-jooq-codegen-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <java.version>17</java.version>
+        <testcontainers.version>1.19.1</testcontainers.version>
+        <testcontainers-jooq-codegen-maven-plugin.version>0.0.4-SNAPSHOT</testcontainers-jooq-codegen-maven-plugin.version>
+        <jooq.version>3.18.3</jooq.version>
+        <postgresql.version>42.6.0</postgresql.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq-codegen</artifactId>
+            <version>${jooq.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+            <version>${jooq.version}</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-jooq-codegen-maven-plugin</artifactId>
+                <version>${testcontainers-jooq-codegen-maven-plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.testcontainers</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>${testcontainers.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.postgresql</groupId>
+                        <artifactId>postgresql</artifactId>
+                        <version>${postgresql.version}</version>
+                    </dependency>
+                </dependencies>
+                <goals>
+                    <goal>generate</goal>
+                </goals>
+                <executions>
+                    <execution>
+                        <id>generate</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>generate-sources</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <database>
+                        <type>POSTGRES</type>
+                        <containerImage>postgres:15-alpine</containerImage>
+                        <username>test</username>
+                        <password>test</password>
+                        <databaseName>test</databaseName>
+                    </database>
+                    <flyway>
+                        <baselineOnMigrate>true</baselineOnMigrate>
+                        <validateMigrationNaming>true</validateMigrationNaming>
+                    </flyway>
+                    <jooq>
+                        <generator>
+                            <database>
+                                <includes>.*</includes>
+                                <inputSchema>public</inputSchema>
+                            </database>
+                            <target>
+                                <packageName>org.jooq.codegen.maven.test</packageName>
+                                <directory>target/generated-sources/jooq</directory>
+                            </target>
+                        </generator>
+                    </jooq>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/pom/postgres-flyway-baseline/src/main/resources/db/migration/B1__baseline.sql
+++ b/src/test/resources/pom/postgres-flyway-baseline/src/main/resources/db/migration/B1__baseline.sql
@@ -1,0 +1,26 @@
+create sequence user_id_seq start with 1 increment by 5;
+
+create table users
+(
+    id                 bigint           DEFAULT nextval('user_id_seq') not null,
+    email              varchar not null,
+    password           varchar not null,
+    name               varchar not null,
+    role               varchar not null,
+    verified           bool    not null default false,
+    verification_token varchar,
+    created_at         timestamp,
+    updated_at         timestamp,
+    primary key (id),
+    CONSTRAINT user_email_unique UNIQUE (email)
+);
+
+create sequence person_id_seq start with 1 increment by 1;
+
+create table person
+(
+  id        bigint default nextval('person_id_seq') not null,
+  firstname varchar(50),
+  lastname  varchar(50)                             not null,
+  state     char(2)
+);


### PR DESCRIPTION
Hey there, great project. 

I having been having issues with a single baseline migration and was able to reproduce this as a test case. I have the setting `<validateMigrationNaming>true</validateMigrationNaming>` so that it fails fast. If you change this to `false`, nothing will get run since I believe flyway ignores names it doesn't understand by default. I have also set the `baselineOnMigrate` to `true` since I believe this is required for this type of setup. 

I validated outside of this maven plugin that a single baseline script will work with the programmatic API. For example:

```java
final Flyway flyway =
    Flyway.configure().dataSource(datasource()).baselineOnMigrate(true).load();
flyway.migrate();
```

Documentation for baseline migrations is here: https://documentation.red-gate.com/fd/baseline-migrations-184127465.html

Possibly related [issue](https://github.com/flyway/flyway/issues/3757) but I really don't see a whole lot of logic in this plugin, so I am not sure what could be missing.
