### PR TITLE
Support flyway v10.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
         <maven-plugin-tools-annotations.version>3.6.1</maven-plugin-tools-annotations.version>
         <testcontainers.version>1.19.1</testcontainers.version>
-        <flyway-core.version>9.16.3</flyway-core.version>
+        <flyway-core.version>10.4.1</flyway-core.version>
         <liquibase-core.version>4.22.0</liquibase-core.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
         <jooq.version>3.18.3</jooq.version>
@@ -115,6 +115,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
@@ -129,6 +135,11 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
+            <version>${flyway-core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
             <version>${flyway-core.version}</version>
         </dependency>
 


### PR DESCRIPTION
Hi, this is a relatively simple change to bump the supported flyway version to 10.4.1.

When using this plugin against a postgres 16.1 database i was getting a warning from flyway that the postgres version was unsupported so thought i'd do a quick PR to bump the flyway version.

I've had to add a new depenedency `flyway-database-postgresql` due to underlying changes in flyway between v9 & v10.

`jackson-annotations` is excluded from the the testcontainers dependency due to a version conflict that resulted in a runtime CassNotFoundException.

Any feedback on this is greatly appreciated :)


 