### PR TITLE
Add support for generic converter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <flyway-core.version>9.16.3</flyway-core.version>
         <liquibase-core.version>4.22.0</liquibase-core.version>
         <junit-jupiter.version>5.9.3</junit-jupiter.version>
-        <jooq.version>3.18.3</jooq.version>
+        <jooq.version>3.19.8</jooq.version>
         <junit.version>4.13.2</junit.version>
         <postgresql.version>42.6.0</postgresql.version>
         <mysql-connector-j.version>8.0.32</mysql-connector-j.version>


### PR DESCRIPTION
Currently if I try to use 

```xml
<forcedType>
    <userType>org.eralmansouri.form.FormDefinition</userType>
    <genericConverter>true</genericConverter>
    <converter>org.eralmansouri.jooq.JacksonConverter</converter>
    <includeExpression>FORM\.DEFINITION</includeExpression>
</forcedType>
```

I get the error `"Cannot find 'genericConverter' in class org.jooq.meta.jaxb.ForcedType"`. The generic converter configuration option was implemented in 3.19.0 or later ([source](https://github.com/jOOQ/jOOQ/issues/15212#issuecomment-1588755939)).

Updating the jooq dependency version to 3.19.8 resolved the issue and the code is correctly generated with the new configuration.