### PR TITLE
chore(deps) : update dependencies and configuration

### DIFF
--- a/examples/postgres-liquibase-example/pom.xml
+++ b/examples/postgres-liquibase-example/pom.xml
@@ -13,10 +13,10 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <testcontainers.version>1.19.1</testcontainers.version>
+        <testcontainers.version>1.20.3</testcontainers.version>
         <testcontainers-jooq-codegen-maven-plugin.version>0.0.4</testcontainers-jooq-codegen-maven-plugin.version>
-        <jooq.version>3.18.3</jooq.version>
-        <postgresql.version>42.6.0</postgresql.version>
+        <jooq.version>3.19.16</jooq.version>
+        <postgresql.version>42.7.4</postgresql.version>
     </properties>
 
     <dependencies>
@@ -74,7 +74,7 @@
                                 <generator>
                                     <database>
                                         <includes>.*</includes>
-                                        <excludes>DATABASECHANGELOG</excludes>
+                                        <excludes>DATABASECHANGELOG.*</excludes>
                                         <inputSchema>custom</inputSchema>
                                     </database>
                                     <target>

--- a/examples/postgres-liquibase-example/pom.xml
+++ b/examples/postgres-liquibase-example/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <testcontainers.version>1.20.3</testcontainers.version>
         <testcontainers-jooq-codegen-maven-plugin.version>0.0.4</testcontainers-jooq-codegen-maven-plugin.version>
-        <jooq.version>3.19.16</jooq.version>
+        <jooq.version>3.19.18</jooq.version>
         <postgresql.version>42.7.4</postgresql.version>
     </properties>
 


### PR DESCRIPTION
With this change we will exclude both `DATABASECHANGELOG` and `DATABASECHANGELOGLOCK` tables instead of only `DATABASECHANGELOG` table currently